### PR TITLE
feat: add NAS auto-mount via SMB LaunchAgent

### DIFF
--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # install.sh — Idempotent dotfiles bootstrap for macOS + zsh
-# Usage: ./install.sh [--minimal] [--no-tools] [--no-macos]
+# Usage: ./install.sh [--minimal] [--no-tools] [--no-macos] [--no-nas]
 #
 # One-liner: curl -fsSL https://raw.githubusercontent.com/Specter099/dotfiles/main/install.sh | bash
 set -euo pipefail
@@ -12,12 +12,14 @@ BACKUP_DIR="$HOME/.dotfiles-backup/$(date +%Y%m%d-%H%M%S)"
 MINIMAL=false
 SKIP_TOOLS=false
 SKIP_MACOS=false
+SKIP_NAS=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
     --minimal)   MINIMAL=true;     shift ;;
     --no-tools)  SKIP_TOOLS=true;  shift ;;
     --no-macos)  SKIP_MACOS=true;  shift ;;
+    --no-nas)    SKIP_NAS=true;    shift ;;
     *) warn "Unknown argument: $1"; shift ;;
   esac
 done
@@ -259,13 +261,23 @@ else
   warn "setup-signed-commits.sh not found in bootstrap/ — skipping"
 fi
 
-# ── 8. macOS preferences ──────────────────────────────────────────────────────
+# ── 8. NAS auto-mount ────────────────────────────────────────────────────────
+if is_mac && ! $SKIP_NAS && ! $MINIMAL; then
+  step "NAS Auto-Mount (SMB)"
+  if [[ -f "$DOTFILES_DIR/bootstrap/setup-nas-mount.sh" ]]; then
+    bash "$DOTFILES_DIR/bootstrap/setup-nas-mount.sh"
+  else
+    warn "setup-nas-mount.sh not found in bootstrap/ — skipping"
+  fi
+fi
+
+# ── 9. macOS preferences ──────────────────────────────────────────────────────
 if is_mac && ! $SKIP_MACOS && ! $MINIMAL; then
   step "macOS Preferences"
   bash "$DOTFILES_DIR/bootstrap/macos.sh"
 fi
 
-# ── 9. fzf shell integration ──────────────────────────────────────────────────
+# ── 10. fzf shell integration ─────────────────────────────────────────────────
 step "fzf Shell Integration"
 if [[ ! -f "$HOME/.fzf.zsh" ]]; then
   "$(brew --prefix)/opt/fzf/install" --key-bindings --completion --no-update-rc --no-bash --no-fish

--- a/bootstrap/setup-nas-mount.sh
+++ b/bootstrap/setup-nas-mount.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# bootstrap/setup-nas-mount.sh — Auto-mount NAS share via SMB LaunchAgent
+# Share: smb://brian@primary.storage.local/brians_storage
+# Mount Point: /Volumes/Brians_Storage
+set -euo pipefail
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+ok()   { echo -e "${GREEN}✓${NC}  $*"; }
+warn() { echo -e "${YELLOW}⚠${NC}  $*"; }
+
+MOUNT_POINT="/Volumes/Brians_Storage"
+PLIST_LABEL="com.brian.nasmount"
+PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+
+# Create mount point (requires sudo)
+if [[ -d "$MOUNT_POINT" ]]; then
+  ok "Mount point exists: $MOUNT_POINT"
+else
+  if sudo -n true 2>/dev/null; then
+    sudo mkdir -p "$MOUNT_POINT"
+    ok "Created mount point: $MOUNT_POINT"
+  else
+    warn "Skipping mount point creation (requires sudo): $MOUNT_POINT"
+    warn "Run manually: sudo mkdir -p $MOUNT_POINT"
+    exit 1
+  fi
+fi
+
+# Unload existing LaunchAgent if present
+launchctl bootout gui/$(id -u) "$PLIST_PATH" 2>/dev/null || true
+ok "Cleared previous LaunchAgent (if any)"
+
+# Write LaunchAgent plist
+mkdir -p "$HOME/Library/LaunchAgents"
+cat > "$PLIST_PATH" << 'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.brian.nasmount</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>mount | grep -q '/Volumes/Brians_Storage' || /sbin/mount_smbfs //brian@primary.storage.local/brians_storage /Volumes/Brians_Storage</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>60</integer>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+PLIST
+ok "Wrote LaunchAgent: $PLIST_PATH"
+
+# Load LaunchAgent
+launchctl bootstrap gui/$(id -u) "$PLIST_PATH"
+ok "Loaded LaunchAgent: $PLIST_LABEL"
+
+# Verify
+if launchctl list | grep -q nasmount; then
+  ok "LaunchAgent running"
+else
+  warn "LaunchAgent may not have loaded — check: launchctl list | grep nasmount"
+fi
+
+echo ""
+echo "Remember: connect manually once via Finder first and"
+echo "check 'Remember this password in my keychain' for silent remounts."


### PR DESCRIPTION
## Summary
- Add `bootstrap/setup-nas-mount.sh` which installs a macOS LaunchAgent to auto-mount `smb://brian@primary.storage.local/brians_storage` to `/Volumes/Brians_Storage` every 60 seconds
- Integrate as step 8 in `install.sh` with `--no-nas` skip flag (also skipped with `--minimal`)
- Idempotent: unloads existing LaunchAgent before recreating; guards sudo for mount point creation

## Test plan
- [ ] Run `bootstrap/setup-nas-mount.sh` standalone and verify LaunchAgent loads (`launchctl list | grep nasmount`)
- [ ] Run `install.sh --no-nas` and verify NAS step is skipped
- [ ] Run `install.sh --minimal` and verify NAS step is skipped
- [ ] Connect to NAS via Finder first and save credentials to Keychain, then verify auto-remount after disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)