### PR TITLE
feat: add SSH config to dotfiles

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -120,6 +120,10 @@ ln -sf $DOTFILES/git/.gitignore_global ~/.gitignore_global
 # Starship
 mkdir -p ~/.config
 ln -sf $DOTFILES/starship/starship.toml ~/.config/starship.toml
+
+# SSH
+mkdir -p ~/.ssh
+ln -sf $DOTFILES/ssh/config              ~/.ssh/config
 ```
 
 ### Step 7: Set up SSH commit signing

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -252,6 +252,7 @@ link "$DOTFILES_DIR/zsh/.zsh_functions"     "$HOME/.zsh_functions"
 link "$DOTFILES_DIR/git/.gitconfig"         "$HOME/.gitconfig"
 link "$DOTFILES_DIR/git/.gitignore_global"  "$HOME/.gitignore_global"
 link "$DOTFILES_DIR/starship/starship.toml" "$HOME/.config/starship.toml"
+link "$DOTFILES_DIR/ssh/config"             "$HOME/.ssh/config"
 
 # ── 7. Signed commits ─────────────────────────────────────────────────────────
 step "SSH Commit Signing"

--- a/ssh/config
+++ b/ssh/config
@@ -1,0 +1,39 @@
+Host *
+  AddKeysToAgent yes
+
+# SSH over Session Manager
+host i-* mi-*
+    ProxyCommand sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
+
+Host github.com
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/github
+
+Host bitwarden
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/Documents/repos/ssh-keys/bitwarden.pem
+  User ubuntu
+  HostKeyAlias i-0f6b0c151c7ac464f
+
+Host apartment-pfsense
+  AddKeysToAgent yes
+  UseKeychain yes
+  User brian
+  HostName 10.0.0.1
+  IdentityFile ~/.ssh/apartment_pfsense
+
+Host dads-pfsense
+  AddKeysToAgent yes
+  UseKeychain yes
+  User brian
+  HostName 192.168.1.1
+  IdentityFile ~/.ssh/house_pfsense
+
+Host shop-pfsense
+  AddKeysToAgent yes
+  UseKeychain yes
+  User brian
+  HostName 192.168.0.1
+  IdentityFile ~/.ssh/pfsense_sg1100


### PR DESCRIPTION
## Summary
- Add `ssh/config` to the dotfiles repo with symlink support
- Update `bootstrap/install.sh` to symlink `ssh/config` → `~/.ssh/config`
- Update `SETUP.md` manual Step 6 with SSH symlink instructions
- Clean up: removed dead `Include git_config` directive and duplicate `AddKeysToAgent` line

## Test plan
- [ ] Run `./bootstrap/install.sh` on a fresh machine and verify `~/.ssh/config` is symlinked
- [ ] Verify `ssh -T git@github.com` still works after symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)