### PR TITLE
feat: add AWS CLI config to dotfiles

### DIFF
--- a/aws/config
+++ b/aws/config
@@ -1,0 +1,152 @@
+[default]
+region = us-east-1
+output = json
+s3 =
+  preferred_transfer_client = crt
+
+[sso-session sso]
+sso_start_url = https://d-90676e3bf9.awsapps.com/start/
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+
+# --- Main (533833010512) ---
+[profile main]
+sso_session = sso
+sso_account_id = 533833010512
+sso_role_name = AdministratorAccess
+region = us-east-1
+output = json
+
+# --- Production (451645558365) ---
+[profile production]
+sso_session = sso
+sso_account_id = 451645558365
+sso_role_name = AdministratorAccess
+region = us-east-1
+
+[profile production-ro]
+sso_session = sso
+sso_account_id = 451645558365
+sso_role_name = ReadOnlyAccess
+region = us-east-1
+
+# --- Sandbox (069513794673) ---
+[profile sandbox]
+sso_session = sso
+sso_account_id = 069513794673
+sso_role_name = AdministratorAccess
+region = us-east-1
+output = json
+
+[profile sandbox-ro]
+sso_session = sso
+sso_account_id = 069513794673
+sso_role_name = ReadOnlyAccess
+region = us-east-1
+
+# --- Knit&Stitch (390402564374) ---
+[profile knit-n-stitch]
+sso_session = sso
+sso_account_id = 390402564374
+sso_role_name = AWSAdministratorAccess
+region = us-east-1
+
+[profile knit-n-stitch-ro]
+sso_session = sso
+sso_account_id = 390402564374
+sso_role_name = ReadOnlyAccess
+region = us-east-1
+
+# --- GenAI (273354657910) ---
+[profile genai]
+sso_session = sso
+sso_account_id = 273354657910
+sso_role_name = AWSAdministratorAccess
+region = us-east-1
+
+[profile genai-ro]
+sso_session = sso
+sso_account_id = 273354657910
+sso_role_name = ReadOnlyAccess
+region = us-east-1
+
+# --- Scissors Hair and Barber (256213927778) ---
+[profile scissors]
+sso_session = sso
+sso_account_id = 256213927778
+sso_role_name = AdministratorAccess
+region = us-east-1
+
+[profile scissors-ro]
+sso_session = sso
+sso_account_id = 256213927778
+sso_role_name = ReadOnlyAccess
+region = us-east-1
+
+# --- Data Collection (880289784800) ---
+[profile data-collection]
+sso_session = sso
+sso_account_id = 880289784800
+sso_role_name = AdministratorAccess
+region = us-east-1
+
+[profile data-collection-ro]
+sso_session = sso
+sso_account_id = 880289784800
+sso_role_name = ReadOnlyAccess
+region = us-east-1
+
+# --- Trust_no1 (124307364559) ---
+[profile trust-no1]
+sso_session = sso
+sso_account_id = 124307364559
+sso_role_name = AdministratorAccess
+region = us-east-1
+
+[profile trust-no1-ro]
+sso_session = sso
+sso_account_id = 124307364559
+sso_role_name = ReadOnlyAccess
+region = us-east-1
+
+# --- Identity Center (211125668566) ---
+[profile identity-center]
+sso_session = sso
+sso_account_id = 211125668566
+sso_role_name = AdministratorAccess
+region = us-east-1
+
+[profile identity-center-ro]
+sso_session = sso
+sso_account_id = 211125668566
+sso_role_name = ReadOnlyAccess
+region = us-east-1
+
+# --- Root Management (869935086182) ---
+[profile root-management]
+sso_session = sso
+sso_account_id = 869935086182
+sso_role_name = AWSAdministratorAccess
+region = us-east-1
+
+[profile root-management-ro]
+sso_session = sso
+sso_account_id = 869935086182
+sso_role_name = ReadOnlyAccess
+region = us-east-1
+
+# --- Organization Management (205930647997) ---
+[profile org-management]
+sso_session = sso
+sso_account_id = 205930647997
+sso_role_name = AWSAdministratorAccess
+region = us-east-1
+
+[profile org-management-ro]
+sso_session = sso
+sso_account_id = 205930647997
+sso_role_name = ReadOnlyAccess
+region = us-east-1
+
+[profile lattice-backup]
+region = us-east-1


### PR DESCRIPTION
## Summary
- Add AWS CLI config file to dotfiles repo under `aws/config`
- Original `~/.aws/config` replaced with symlink pointing to this repo

## Test plan
- [ ] Verify `~/.aws/config` symlink resolves correctly
- [ ] Verify `aws sts get-caller-identity` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)