### PR TITLE
feat: add Claude Code statusline script

### DIFF
--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -244,7 +244,7 @@ done
 # ── 6. Symlink dotfiles ───────────────────────────────────────────────────────
 step "Symlinking Dotfiles"
 
-mkdir -p "$HOME/.config" "$HOME/.ssh"
+mkdir -p "$HOME/.config" "$HOME/.ssh" "$HOME/.claude"
 
 link "$DOTFILES_DIR/zsh/.zshrc"             "$HOME/.zshrc"
 link "$DOTFILES_DIR/zsh/.zsh_aliases"       "$HOME/.zsh_aliases"
@@ -253,6 +253,7 @@ link "$DOTFILES_DIR/git/.gitconfig"         "$HOME/.gitconfig"
 link "$DOTFILES_DIR/git/.gitignore_global"  "$HOME/.gitignore_global"
 link "$DOTFILES_DIR/starship/starship.toml" "$HOME/.config/starship.toml"
 link "$DOTFILES_DIR/ssh/config"             "$HOME/.ssh/config"
+link "$DOTFILES_DIR/claude/statusline-command.sh" "$HOME/.claude/statusline-command.sh"
 
 # ── 7. Signed commits ─────────────────────────────────────────────────────────
 step "SSH Commit Signing"

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Claude Code status line script
+
+input=$(cat)
+
+# --- Directory ---
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
+dir=$(basename "$cwd")
+
+# --- Git branch and status ---
+git_part=""
+if git -C "$cwd" rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
+  branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null \
+           || git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
+  indicators=""
+  if ! git -C "$cwd" diff --no-ext-diff --quiet --cached 2>/dev/null; then
+    indicators="${indicators}+"
+  fi
+  if ! git -C "$cwd" diff --no-ext-diff --quiet 2>/dev/null; then
+    indicators="${indicators}*"
+  fi
+  git_part=" \033[90m|\033[0m \033[36m${branch}${indicators}\033[0m"
+fi
+
+# --- Model ---
+model=$(echo "$input" | jq -r '.model.display_name // ""')
+
+# --- Context usage ---
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+if [ -n "$used_pct" ]; then
+  ctx_str=$(printf "%.0f%%" "$used_pct")
+  if awk "BEGIN{exit !($used_pct > 80)}"; then
+    ctx_color="\033[31m"
+  elif awk "BEGIN{exit !($used_pct > 50)}"; then
+    ctx_color="\033[33m"
+  else
+    ctx_color="\033[32m"
+  fi
+  ctx_part=" \033[90m|\033[0m ${ctx_color}ctx:${ctx_str}\033[0m"
+else
+  ctx_part=""
+fi
+
+# --- AWS profile ---
+aws_profile="${AWS_PROFILE:-}"
+if [ -n "$aws_profile" ]; then
+  aws_part=" \033[90m|\033[0m \033[33maws:${aws_profile}\033[0m"
+else
+  aws_part=""
+fi
+
+# --- Python venv ---
+virtual_env="${VIRTUAL_ENV:-}"
+if [ -n "$virtual_env" ]; then
+  venv_name=$(basename "$virtual_env")
+  if [ "$venv_name" = ".venv" ] || [ "$venv_name" = "venv" ]; then
+    venv_name=$(basename "$(dirname "$virtual_env")")
+  fi
+  venv_part=" \033[90m|\033[0m \033[35mpy:${venv_name}\033[0m"
+else
+  venv_part=""
+fi
+
+# --- Assemble ---
+printf "%b%b \033[90m|\033[0m \033[34m%s\033[0m%b%b%b\n" \
+  "\033[1m${dir}\033[0m" \
+  "$git_part" \
+  "$model" \
+  "$ctx_part" \
+  "$aws_part" \
+  "$venv_part"


### PR DESCRIPTION
## Summary
- Adds `claude/statusline-command.sh` — custom Claude Code statusline showing git branch, dirty/staged indicators, model, context usage, AWS profile, and Python venv
- Updates `bootstrap/install.sh` to symlink the script into `~/.claude/` during bootstrap

## Test plan
- [ ] Run `install.sh` and verify `~/.claude/statusline-command.sh` is symlinked
- [ ] Open Claude Code and confirm statusline renders with colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)